### PR TITLE
Allow theme overrides

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,3 +2,32 @@
 
 This is a custom Wordpress plugin that adds custom toolbars to the Wordpress WYSIWYG editor interface.
 It was developed at NewCity, and depends in part on the [NewCity Custom Shortcodes](https://github.com/newcity/newcity-wp-shortcodes) Wordpress plugin.
+
+## Theme customization
+
+Your theme may override some settings added by this plugin using configuration file `wysiwyg-config.json` in the root of the active theme. This file may define the custom stylesheet used by TinyMCE (relative to the theme root) and provide the `styles_format` configuration for the format dropdown. For example:
+
+```json
+{
+    "css": "css/wysiwyg.css",
+    "styles_format": [
+        {
+            "title": "Button link",
+            "selector": "a",
+            "classes": "button"
+        },
+        {
+            "title": "Go link",
+            "selector": "a",
+            "classes": "go"
+        },
+        {
+            "title": "Intro paragraph",
+            "selector": "p",
+            "classes": "intro"
+        }
+    ]
+}
+```
+
+If this configuration is not present, the plugin will supply its defaults.

--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ Your theme may override some settings added by this plugin using configuration f
 ```json
 {
     "css": "css/wysiwyg.css",
-    "styles_format": [
+    "style_formats": [
         {
             "title": "Button link",
             "selector": "a",

--- a/class-newcity-toolbars.php
+++ b/class-newcity-toolbars.php
@@ -72,13 +72,13 @@ class NewCityToolbars {
 		);
 
 		// check for overrides in the theme
-		$config_fn = get_template_directory() . '/' . $this->theme_config_file;
+		$config_fn = get_stylesheet_directory() . '/' . $this->theme_config_file;
 		if (file_exists($config_fn)) {
 			$contents = file_get_contents($config_fn);
 			$config = json_decode($contents, TRUE);
 			if ($config) {
 				if (isset($config['css'])) {
-					$this->stylesheet = get_template_directory() . '/' . $config['css'];
+					$this->stylesheet = get_stylesheet_directory() . '/' . $config['css'];
 				}
 				if (isset($config['style_formats'])) {
 					$this->style_formats = $config['style_formats'];

--- a/class-newcity-toolbars.php
+++ b/class-newcity-toolbars.php
@@ -12,20 +12,50 @@
 
 class NewCityToolbars {
 
+	/**
+	 * name of the theme config override
+	 * if this file exists at the root of the current theme and is valid json, it will be parsed for keys:
+	 *   - css : path of the wysiwyg css, relative to the theme root
+	 *   - styles_format : styles format array for TinyMCE config, see e.g., https://www.tinymce.com/docs-3x/reference/configuration/Configuration3x@style_formats/
+	 *
+	 * @var string
+	 */
+	private $theme_config_file = "wysiwyg-config.json";
+
+	/**
+	 * Path to custom stylesheet
+	 *
+	 * @var string
+	 */
+	private $stylesheet;
+
+	/**
+	 * TinyMCE styles array
+	 *
+	 * @var array
+	 */
+	private $styles_formats;
+
+
 	public function __construct() {
-		add_editor_style( plugins_url( 'wysiwyg-styles.css', __FILE__ ) );
+
+		// set defaults, override by theme config if it exists
+		$this->get_custom_styles();
+
+		add_action( 'admin_init', array( $this, 'add_editor_styles') );
 		add_filter( 'tiny_mce_before_init', array( $this, 'modify_tiny_mce' ) );
-		add_action( 'init', array( $this, 'register_mce_toolbar' ) );
+
+
 		add_filter( 'acf/fields/wysiwyg/toolbars', array( $this, 'my_toolbars' ) );
+
+		add_filter( 'mce_buttons', array( $this, 'default_mce_toolbar' ) );
+		add_filter( 'mce_buttons', array( $this, 'add_style_select_buttons' ) );
+		add_filter( 'mce_buttons_2', array( $this, 'extra_mce_toolbar' ) );
 	}
 
-	public function modify_tiny_mce( $settings ) {
-		// Set dropdown formatting options in WYSIWYG Editor
-		// {Display Name}={html tag}
-		$settings['block_formats'] = 'Paragraph=p;Heading 2=h2;Heading 3=h3;Heading 4=h4;';
-
-
-		$style_formats = array(
+	private function get_custom_styles() {
+		$this->stylesheet = plugins_url( 'wysiwyg-styles.css', __FILE__ );
+		$this->styles_formats = array(
 			array(
 				'title' => 'Intro Paragraph',
 				'block' => 'p',
@@ -41,74 +71,40 @@ class NewCityToolbars {
 			),
 		);
 
-		$settings['style_formats'] = json_encode( $style_formats );
+		// check for overrides in the theme
+		$config_fn = get_template_directory() . '/' . $this->theme_config_file;
+		if (file_exists($config_fn)) {
+			$contents = file_get_contents($config_fn);
+			$config = json_decode($contents, TRUE);
+			if ($config) {
+				if (isset($config['css'])) {
+					$this->stylesheet = get_template_directory() . '/' . $config['css'];
+				}
+				if (isset($config['style_formats'])) {
+					$this->style_formats = $config['style_formats'];
+				}
+			}
+		}
+	}
+
+	public function add_editor_styles() {
+
+		add_editor_style(  );
+	}
+
+	public function modify_tiny_mce( $settings ) {
+		// Set dropdown formatting options in WYSIWYG Editor
+		// {Display Name}={html tag}
+		$settings['block_formats'] = 'Paragraph=p;Heading 2=h2;Heading 3=h3;Heading 4=h4;';
+
+		$settings['style_formats'] = json_encode( $this->style_formats );
 
 		return $settings;
 	}
 
-	private function blockquote_name() {
-		if ( shortcode_exists( 'newcity_blockquote' ) ) {
-			return 'newcity_blockquote';
-		}
-		
-		return 'blockquote';
-	}
-
-	private function custom_styles( $init_array ) {
-		$style_formats = array(
-			array(
-				'title' => 'Intro Paragraph',
-				'block' => 'p',
-				'classes' => 'intro',
-				'wrapper' => false,
-			),
-			array(
-				'title' => 'Featured Link',
-				'selector' => 'a',
-				'block' => 'a',
-				'classes' => 'large-arrow',
-				'wrapper' => false,
-			),
-		);
-
-		$init_array['style_formats'] = json_encode( $style_formats );
-		return $init_array;
-	}
-
-	function add_style_select_buttons( $buttons ) {
+	public function add_style_select_buttons( $buttons ) {
 		array_unshift( $buttons, 'styleselect' );
 		return $buttons;
-	}
-
-	function my_toolbars( $toolbars ) {
-		// Add new WYSIWYG toolbar sets
-
-
-		$toolbars['Minimum'] = array();
-		$toolbars['Minimum'][1] = array( 'bold', 'italic', '|', 'removeformat' );
-
-		$toolbars['Minimum with Links'] = array();
-		$toolbars['Minimum with Links'][1] = array( 'bold', 'italic', 'link', 'unlink', '|', 'removeformat' );
-
-		$toolbars['Minimum with Lists'] = array();
-		$toolbars['Minimum with Lists'][1] = array( 'bold', 'italic', 'link', 'unlink', '|', 'bullist', 'numlist', '|', 'removeformat' );
-
-		$toolbars['Simple'] = array();
-		$toolbars['Simple'][1] = array( 'bold', 'italic', 'link', 'unlink', 'bullist', 'numlist', $this->blockquote_name(), '|', 'removeformat' );
-
-		$toolbars['Simple with Headers'] = array();
-		$toolbars['Simple with Headers'][1] = array( 'bold', 'italic', 'link', 'unlink', 'bullist', 'numlist', $this->blockquote_name(), 'formatselect', 'styleselect', '|', 'removeformat' );
-
-		// Edit the "Full" toolbar and remove 'code'
-		// if (($key = array_search('code', $toolbars['Full' ][2])) !== false) {
-		//     unset($toolbars['Full' ][2][$key]);
-		// }
-
-		// remove the 'Basic' toolbar completely
-		unset( $toolbars['Basic'] );
-
-		// return $toolbars - IMPORTANT!
-		return $toolbars;
 	}
 
 	public function default_mce_toolbar( $buttons ) {
@@ -120,9 +116,11 @@ class NewCityToolbars {
 		return $buttons;
 	}
 
-	function register_mce_toolbar() {
-		add_filter( 'mce_buttons', array( $this, 'default_mce_toolbar' ) );
-		add_filter( 'mce_buttons', array( $this, 'add_style_select_buttons' ) );
-		add_filter( 'mce_buttons_2', array( $this, 'extra_mce_toolbar' ) );
+	private function blockquote_name() {
+		if ( shortcode_exists( 'newcity_blockquote' ) ) {
+			return 'newcity_blockquote';
+		}
+		
+		return 'blockquote';
 	}
 }

--- a/class-newcity-toolbars.php
+++ b/class-newcity-toolbars.php
@@ -78,7 +78,7 @@ class NewCityToolbars {
 			$config = json_decode($contents, TRUE);
 			if ($config) {
 				if (isset($config['css'])) {
-					$this->stylesheet = get_stylesheet_directory() . '/' . $config['css'];
+					$this->stylesheet = $config['css'];
 				}
 				if (isset($config['style_formats'])) {
 					$this->style_formats = $config['style_formats'];

--- a/class-newcity-toolbars.php
+++ b/class-newcity-toolbars.php
@@ -34,7 +34,7 @@ class NewCityToolbars {
 	 *
 	 * @var array
 	 */
-	private $styles_formats;
+	private $style_formats;
 
 
 	public function __construct() {
@@ -55,7 +55,7 @@ class NewCityToolbars {
 
 	private function get_custom_styles() {
 		$this->stylesheet = plugins_url( 'wysiwyg-styles.css', __FILE__ );
-		$this->styles_formats = array(
+		$this->style_formats = array(
 			array(
 				'title' => 'Intro Paragraph',
 				'block' => 'p',

--- a/class-newcity-toolbars.php
+++ b/class-newcity-toolbars.php
@@ -45,8 +45,7 @@ class NewCityToolbars {
 		add_action( 'admin_init', array( $this, 'add_editor_styles') );
 		add_filter( 'tiny_mce_before_init', array( $this, 'modify_tiny_mce' ) );
 
-
-		add_filter( 'acf/fields/wysiwyg/toolbars', array( $this, 'my_toolbars' ) );
+		add_filter( 'acf/fields/wysiwyg/toolbars', array( $this, 'toolbar_sets' ) );
 
 		add_filter( 'mce_buttons', array( $this, 'default_mce_toolbar' ) );
 		add_filter( 'mce_buttons', array( $this, 'add_style_select_buttons' ) );
@@ -98,6 +97,28 @@ class NewCityToolbars {
 		$settings['style_formats'] = json_encode( $this->style_formats );
 
 		return $settings;
+	}
+
+	public function toolbar_sets( $toolbars ) {
+		// Add new WYSIWYG toolbar sets
+		$toolbars['Minimum'] = array();
+		$toolbars['Minimum'][1] = array( 'bold', 'italic', '|', 'removeformat' );
+		$toolbars['Minimum with Links'] = array();
+		$toolbars['Minimum with Links'][1] = array( 'bold', 'italic', 'link', 'unlink', '|', 'removeformat' );
+		$toolbars['Minimum with Lists'] = array();
+		$toolbars['Minimum with Lists'][1] = array( 'bold', 'italic', 'link', 'unlink', '|', 'bullist', 'numlist', '|', 'removeformat' );
+		$toolbars['Simple'] = array();
+		$toolbars['Simple'][1] = array( 'bold', 'italic', 'link', 'unlink', 'bullist', 'numlist', $this->blockquote_name(), '|', 'removeformat' );
+		$toolbars['Simple with Headers'] = array();
+		$toolbars['Simple with Headers'][1] = array( 'bold', 'italic', 'link', 'unlink', 'bullist', 'numlist', $this->blockquote_name(), 'formatselect', 'styleselect', '|', 'removeformat' );
+		// Edit the "Full" toolbar and remove 'code'
+		// if (($key = array_search('code', $toolbars['Full' ][2])) !== false) {
+		//     unset($toolbars['Full' ][2][$key]);
+		// }
+		// remove the 'Basic' toolbar completely
+		unset( $toolbars['Basic'] );
+		// return $toolbars - IMPORTANT!
+		return $toolbars;
 	}
 
 	public function add_style_select_buttons( $buttons ) {

--- a/class-newcity-toolbars.php
+++ b/class-newcity-toolbars.php
@@ -88,8 +88,7 @@ class NewCityToolbars {
 	}
 
 	public function add_editor_styles() {
-
-		add_editor_style(  );
+		add_editor_style( $this->stylesheet );
 	}
 
 	public function modify_tiny_mce( $settings ) {

--- a/class-newcity-toolbars.php
+++ b/class-newcity-toolbars.php
@@ -95,7 +95,6 @@ class NewCityToolbars {
 		// Set dropdown formatting options in WYSIWYG Editor
 		// {Display Name}={html tag}
 		$settings['block_formats'] = 'Paragraph=p;Heading 2=h2;Heading 3=h3;Heading 4=h4;';
-
 		$settings['style_formats'] = json_encode( $this->style_formats );
 
 		return $settings;

--- a/newcity-wysiwyg.php
+++ b/newcity-wysiwyg.php
@@ -24,8 +24,4 @@
 
 require_once( dirname( __FILE__ ) . '/class-newcity-toolbars.php');
 
-function newcity_wysiwyg_run() {
-	$brpa_filters = new NewCityToolbars();
-}
-
-newcity_wysiwyg_run();
+new NewCityToolbars();


### PR DESCRIPTION
This shouldn't change existing functionality of the plugin, but allows a theme to define custom styles and stylesheet with a json file.

See https://github.com/ahebrank/newcity-wp-wysiwyg/blob/theme-overrides/Readme.md